### PR TITLE
Workaround: #37 - Added base pathing in static js 

### DIFF
--- a/netbox_floorplan/static/netbox_floorplan/floorplan/edit.js
+++ b/netbox_floorplan/static/netbox_floorplan/floorplan/edit.js
@@ -12,8 +12,9 @@ import {
     start_pan,
     move_pan,
     reset_zoom,
-    init_floor_plan
-} from "/static/netbox_floorplan/floorplan/utils.js";
+    init_floor_plan,
+    netbox_root
+} from "./utils.js";
 
 var csrf = document.getElementById('csrf').value;
 var obj_pk = document.getElementById('obj_pk').value;
@@ -22,8 +23,8 @@ var record_type = document.getElementById('record_type').value;
 var site_id = document.getElementById('site_id').value;
 var location_id = document.getElementById('location_id').value;
 
-htmx.ajax('GET', `/plugins/floorplan/floorplans/racks/?floorplan_id=${obj_pk}`, { target: '#rack-card', swap: 'innerHTML', trigger: 'load' })
-htmx.ajax('GET', `/plugins/floorplan/floorplans/devices/?floorplan_id=${obj_pk}`, { target: '#unrack-card', swap: 'innerHTML', trigger: 'load' })
+htmx.ajax('GET', `${netbox_root}/plugins/floorplan/floorplans/racks/?floorplan_id=${obj_pk}`, { target: '#rack-card', swap: 'innerHTML', trigger: 'load' })
+htmx.ajax('GET', `${netbox_root}/plugins/floorplan/floorplans/devices/?floorplan_id=${obj_pk}`, { target: '#unrack-card', swap: 'innerHTML', trigger: 'load' })
 
 fabric.Object.prototype.set({
     snapThreshold: 45,
@@ -389,8 +390,8 @@ function delete_floorplan_object() {
     }
     save_floorplan();
     setTimeout(() => {
-        htmx.ajax('GET', `/plugins/floorplan/floorplans/racks/?floorplan_id=${obj_pk}`, { target: '#rack-card', swap: 'innerHTML' });
-        htmx.ajax('GET', `/plugins/floorplan/floorplans/devices/?floorplan_id=${obj_pk}`, { target: '#unrack-card', swap: 'innerHTML' });
+        htmx.ajax('GET', `${netbox_root}/plugins/floorplan/floorplans/racks/?floorplan_id=${obj_pk}`, { target: '#rack-card', swap: 'innerHTML' });
+        htmx.ajax('GET', `${netbox_root}/plugins/floorplan/floorplans/devices/?floorplan_id=${obj_pk}`, { target: '#unrack-card', swap: 'innerHTML' });
     }, 1500);
 };
 window.delete_floorplan_object = delete_floorplan_object;
@@ -464,7 +465,7 @@ function update_dimensions() {
     var floor_json = canvas.toJSON(["id", "text", "_controlsVisibility", "custom_meta", "lockMovementY", "lockMovementX", "evented", "selectable"]);
     $.ajax({
         type: "PATCH",
-        url: `/api/plugins/floorplan/floorplans/${obj_pk}/`,
+        url: `${netbox_root}/api/plugins/floorplan/floorplans/${obj_pk}/`,
         dataType: "json",
         headers: {
             "X-CSRFToken": csrf,
@@ -635,7 +636,7 @@ function save_floorplan() {
     var floor_json = canvas.toJSON(["id", "text", "_controlsVisibility", "custom_meta", "lockMovementY", "lockMovementX", "evented", "selectable"]);
     $.ajax({
         type: "PATCH",
-        url: `/api/plugins/floorplan/floorplans/${obj_pk}/`,
+        url: `${netbox_root}/api/plugins/floorplan/floorplans/${obj_pk}/`,
         dataType: "json",
         headers: {
             "X-CSRFToken": csrf,
@@ -654,7 +655,7 @@ function save_and_redirect() {
     var floor_json = canvas.toJSON(["id", "text", "_controlsVisibility", "custom_meta", "lockMovementY", "lockMovementX", "evented", "selectable"]);
     $.ajax({
         type: "PATCH",
-        url: `/api/plugins/floorplan/floorplans/${obj_pk}/`,
+        url: `${netbox_root}/api/plugins/floorplan/floorplans/${obj_pk}/`,
         dataType: "json",
         headers: {
             "X-CSRFToken": csrf,
@@ -668,9 +669,9 @@ function save_and_redirect() {
         }
     }).done(function () {
         if (record_type == "site") {
-            window.location.href = `/dcim/sites/${site_id}/floorplans/`;
+            window.location.href = `${netbox_root}/dcim/sites/${site_id}/floorplans/`;
         } else {
-            window.location.href = `/dcim/locations/${location_id}/floorplans/`;
+            window.location.href = `${netbox_root}/dcim/locations/${location_id}/floorplans/`;
         }
     });
 }

--- a/netbox_floorplan/static/netbox_floorplan/floorplan/utils.js
+++ b/netbox_floorplan/static/netbox_floorplan/floorplan/utils.js
@@ -9,8 +9,14 @@ export {
     stop_pan,
     start_pan,
     move_pan,
-    init_floor_plan
+    init_floor_plan,
+    netbox_root
 };
+
+// Specify the base path where netbox is hosted here
+// If the base path is '/', just leave it empty
+// Otherwise, it must always start with '/' and should never end with '/' (e.g. '/netbox', '/apps/netbox')
+const netbox_root = ""
 
 function resize_canvas(canvas, window) {
     var bob_width = $("#content-container").width();
@@ -138,7 +144,7 @@ function init_floor_plan(floorplan_id, canvas, mode) {
         return;
     }
 
-    const floorplan_call = $.get(`/api/plugins/floorplan/floorplans/?id=${floorplan_id}`);
+    const floorplan_call = $.get(`${netbox_root}/api/plugins/floorplan/floorplans/?id=${floorplan_id}`);
     floorplan_call.done(function (floorplan) {
         floorplan.results.forEach((floorplan) => {
             canvas.loadFromJSON(JSON.stringify(floorplan.canvas), canvas.renderAll.bind(canvas), function (o, object) {

--- a/netbox_floorplan/static/netbox_floorplan/floorplan/view.js
+++ b/netbox_floorplan/static/netbox_floorplan/floorplan/view.js
@@ -7,7 +7,7 @@ import {
     start_pan,
     reset_zoom,
     init_floor_plan
-} from "/static/netbox_floorplan/floorplan/utils.js";
+} from "./utils.js";
 
 var canvas = new fabric.Canvas('canvas');
 


### PR DESCRIPTION
Workaround for #37 
Okay, so the static files `edit.js` and `utils.js` don't really have a mechanism for relative path referencing. I've patched the scripts so it should be fine now. Unfortunately, I couldn't find a way to not hard-code `netbox_root`, but at least I got it in one place only so the workaround isn't hard to apply. Mind you, I'm not a frontend developer, so I don't know how feasible it is to do this without a build process.