### PR TITLE
feat: add image objects by link

### DIFF
--- a/netbox_floorplan/static/netbox_floorplan/floorplan/edit.js
+++ b/netbox_floorplan/static/netbox_floorplan/floorplan/edit.js
@@ -138,6 +138,20 @@ function add_wall() {
 }
 window.add_wall = add_wall;
 
+function add_image() {
+  let url = prompt('Please enter image URL');
+
+  if(url==='' || url===null)
+    return;
+
+  fabric.Image.fromURL(url, function (img) {
+    canvas.add(img);
+    canvas.centerObject(img);
+  });
+}
+
+window.add_image = add_image;
+
 function add_area() {
     var wall = new fabric.Rect({
         top: 0,

--- a/netbox_floorplan/templates/netbox_floorplan/floorplan_edit.html
+++ b/netbox_floorplan/templates/netbox_floorplan/floorplan_edit.html
@@ -103,6 +103,9 @@
                                         <a type="button" class="btn btn-outline-info" onclick="add_area()">Add
                                             Area
                                         </a>
+                                        <a type="button" class="btn btn-outline-info" onclick="add_image()">Add
+                                            Image
+                                        </a>
                                         <a class="btn btn-outline-success" onclick="add_text()">
                                             Add label
                                         </a>


### PR DESCRIPTION
This PR adds custom images on the floorpan. 
I don't have enough knowledge of the Netbox core to implement full image uploading, so it only supports links. You can use Image Attachments as an image source.
