### PR TITLE
Include child locations in rack/device lists for location floorplans

### DIFF
--- a/netbox_floorplan/views.py
+++ b/netbox_floorplan/views.py
@@ -119,7 +119,7 @@ class FloorplanRackListView(generic.ObjectListView):
                 site=fp_instance.site.id).order_by("name")
         else:
             self.queryset = Rack.objects.all().select_related("role").filter(~Q(id__in=fp_instance.mapped_racks)).filter(
-                location=fp_instance.location.id).order_by("name")
+                location__in=fp_instance.location.get_descendants(include_self=True)).order_by("name")
         return super().get(request)
 
 
@@ -135,7 +135,7 @@ class FloorplanDeviceListView(generic.ObjectListView):
                 site=fp_instance.site.id, rack=None).order_by("name")
         else:
             self.queryset = Device.objects.all().filter(~Q(id__in=fp_instance.mapped_devices)).filter(
-                location=fp_instance.location.id, rack=None).order_by("name")
+                location__in=fp_instance.location.get_descendants(include_self=True), rack=None).order_by("name")
         return super().get(request)
 
 


### PR DESCRIPTION
## Problem

When a floorplan is attached to a **parent location**, the rack and device
pick-lists in the editor filter on an exact location match
(`location=fp_instance.location.id`). Racks are usually assigned to leaf
locations (rooms, rows), so a floorplan on the parent location offers
nothing to place.

Typical case: a datacenter location split into several room locations,
with every rack assigned to a room. The datacenter-level floorplan shows
an empty rack list, making a global datacenter view impossible.

## Solution

Filter on the location's descendants instead of an exact match, in both
`FloorplanRackListView` and `FloorplanDeviceListView`:

```python
location__in=fp_instance.location.get_descendants(include_self=True)
```

`Location` is a tree model, so `get_descendants(include_self=True)` is
available natively. Leaf locations keep the exact same behaviour as
before (`include_self=True`, no descendants), so this is strictly
additive: only parent-location floorplans gain the racks/devices of
their children.

## Tested

On NetBox 5.0.1, with a parent location whose racks all live in child
locations: before the change, the parent-location floorplan offered no
racks at all; after, every rack from the child locations is offered,
and child-location floorplans behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
